### PR TITLE
Added support for rotation

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -41,14 +41,15 @@ impl SwayFrontend {
 					if saved.width > 0 && saved.height > 0 {
 						l += &format!(" resolution {}x{}", saved.width, saved.height);
 					}
-					if saved.rotation > 0 {
-						l += &format!(" transform {}", saved.rotation);
+					let mut v = ["90".to_string(),"180".into(),"270".into(),"flipped".into(),"flipped-90".into(),"flipped-180".into(),"flipped-270".into()];
+					if v.contains(&saved.transform) {
+						l += &format!(" transform {}", saved.transform.trim());
 					} else {
 						l += &format!(" transform normal");
 					}
 					if saved.scale > 0. {
 						l += &format!(" scale {}", saved.scale);
-					}
+					}					
 					cmds.push(l);
 
 					if saved.primary {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -9,6 +9,7 @@ use self::i3ipc::I3Connection;
 
 use backend::ConnectedOutput;
 use store::SavedOutput;
+use store::Transform;
 
 #[derive(Debug)]
 pub struct MatchedOutput<'a> {
@@ -41,15 +42,19 @@ impl SwayFrontend {
 					if saved.width > 0 && saved.height > 0 {
 						l += &format!(" resolution {}x{}", saved.width, saved.height);
 					}
-					let mut v = ["90".to_string(),"180".into(),"270".into(),"flipped".into(),"flipped-90".into(),"flipped-180".into(),"flipped-270".into()];
-					if v.contains(&saved.transform) {
-						l += &format!(" transform {}", saved.transform.trim());
-					} else {
-						l += &format!(" transform normal");
-					}
+					l += &format!(" transform {}", match saved.transform {
+					Transform::Rotation(90) => "90",
+					Transform::Rotation(180) => "180",
+					Transform::Rotation(270) => "270",
+					Transform::FlippedRotation(0) => "flipped",
+					Transform::FlippedRotation(90) => "flipped-90",
+					Transform::FlippedRotation(180) => "flipped-180",
+					Transform::FlippedRotation(270) => "flipped-270",
+					_ => "normal"
+					});
 					if saved.scale > 0. {
 						l += &format!(" scale {}", saved.scale);
-					}					
+					}
 					cmds.push(l);
 
 					if saved.primary {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -41,6 +41,11 @@ impl SwayFrontend {
 					if saved.width > 0 && saved.height > 0 {
 						l += &format!(" resolution {}x{}", saved.width, saved.height);
 					}
+					if saved.rotation > 0 {
+						l += &format!(" transform {}", saved.rotation);
+					} else {
+						l += &format!(" transform normal");
+					}
 					if saved.scale > 0. {
 						l += &format!(" scale {}", saved.scale);
 					}

--- a/src/store.rs
+++ b/src/store.rs
@@ -22,7 +22,7 @@ pub struct SavedOutput {
 	pub rate: f32,
 	pub x: i32,
 	pub y: i32,
-	pub rotation: i32,
+	pub transform: String,
 	//pub reflect_x: bool,
 	//pub reflect_y: bool,
 	pub primary: bool,
@@ -91,10 +91,10 @@ impl Store for GnomeStore {
 				}
 				if let Some(c) = e.get_child("rotation") {
 					match c.text.as_ref().unwrap().trim() {
-						"right" => o.rotation = 90,
-						"inverted" => o.rotation = 180,
-						"left" => o.rotation = 270,
-						_ => o.rotation = 0,
+						"right" => o.transform = "90".to_string(),
+						"inverted" => o.transform = "180".to_string(),
+						"left" => o.transform = "270".to_string(),
+						_ => o.transform = "normal".to_string(),
 					};
 				}
 				if let Some(c) = e.get_child("primary") {
@@ -133,7 +133,7 @@ enum OutputArg {
 	Disable,
 	Resolution(i32, i32),
 	Position(i32, i32),
-	Rotation(i32),
+	Transform(String),
 	Scale(f32),
 }
 
@@ -154,7 +154,7 @@ fn parse_output_with_args(name: String, args: Vec<OutputArg>) -> SavedOutput {
 				o.x = x;
 				o.y = y;
 			},
-			OutputArg::Rotation(r) => o.rotation = r,
+			OutputArg::Transform(t) => o.transform = t,
 			OutputArg::Scale(f) => o.scale = f,
 		}
 	}
@@ -211,11 +211,11 @@ named!(parse_position<&[u8], OutputArg>, do_parse!(
 	>> (OutputArg::Position(x, y))
 ));
 
-named!(parse_rotation<&[u8], OutputArg>, do_parse!(
-	tag!("rotation")
+named!(parse_transform<&[u8], OutputArg>, do_parse!(
+	tag!("transform")
 	>> parse_space
-	>> r: parse_i32
-	>> (OutputArg::Rotation(r))
+	>> t: parse_string
+	>> (OutputArg::Transform(t))
 ));
 
 named!(parse_f32<&[u8], f32>, ws!(nom::float));
@@ -229,7 +229,7 @@ named!(parse_scale<&[u8], OutputArg>, do_parse!(
 
 named!(parse_output_arg<&[u8], OutputArg>, alt!(
 	parse_vendor | parse_product | parse_serial |
-	parse_disable | parse_resolution | parse_position | parse_rotation | parse_scale
+	parse_disable | parse_resolution | parse_position | parse_transform | parse_scale
 ));
 
 enum ConfigurationArg {

--- a/src/store.rs
+++ b/src/store.rs
@@ -22,7 +22,7 @@ pub struct SavedOutput {
 	pub rate: f32,
 	pub x: i32,
 	pub y: i32,
-	//pub rotation: Rotation,
+	pub rotation: i32,
 	//pub reflect_x: bool,
 	//pub reflect_y: bool,
 	pub primary: bool,
@@ -89,6 +89,14 @@ impl Store for GnomeStore {
 				if let Some(c) = e.get_child("y") {
 					o.y = c.text.as_ref().unwrap().parse::<i32>().unwrap()
 				}
+				if let Some(c) = e.get_child("rotation") {
+					match c.text.as_ref().unwrap().trim() {
+						"right" => o.rotation = 90,
+						"inverted" => o.rotation = 180,
+						"left" => o.rotation = 270,
+						_ => o.rotation = 0,
+					};
+				}
 				if let Some(c) = e.get_child("primary") {
 					o.primary = parse_bool(c.text.as_ref().unwrap())
 				}
@@ -125,6 +133,7 @@ enum OutputArg {
 	Disable,
 	Resolution(i32, i32),
 	Position(i32, i32),
+	Rotation(i32),
 	Scale(f32),
 }
 
@@ -145,6 +154,7 @@ fn parse_output_with_args(name: String, args: Vec<OutputArg>) -> SavedOutput {
 				o.x = x;
 				o.y = y;
 			},
+			OutputArg::Rotation(r) => o.rotation = r,
 			OutputArg::Scale(f) => o.scale = f,
 		}
 	}
@@ -201,6 +211,13 @@ named!(parse_position<&[u8], OutputArg>, do_parse!(
 	>> (OutputArg::Position(x, y))
 ));
 
+named!(parse_rotation<&[u8], OutputArg>, do_parse!(
+	tag!("rotation")
+	>> parse_space
+	>> r: parse_i32
+	>> (OutputArg::Rotation(r))
+));
+
 named!(parse_f32<&[u8], f32>, ws!(nom::float));
 
 named!(parse_scale<&[u8], OutputArg>, do_parse!(
@@ -212,7 +229,7 @@ named!(parse_scale<&[u8], OutputArg>, do_parse!(
 
 named!(parse_output_arg<&[u8], OutputArg>, alt!(
 	parse_vendor | parse_product | parse_serial |
-	parse_disable | parse_resolution | parse_position | parse_scale
+	parse_disable | parse_resolution | parse_position | parse_rotation | parse_scale
 ));
 
 enum ConfigurationArg {

--- a/src/store.rs
+++ b/src/store.rs
@@ -9,6 +9,31 @@ use std::path::PathBuf;
 use std::str;
 use std::str::FromStr;
 
+#[derive(Debug)]
+pub enum Transform {
+	Rotation(i32),
+	FlippedRotation(i32)
+}
+impl Default for Transform {
+	fn default() -> Transform {
+		Transform::Rotation(0)
+	}
+}
+impl Transform {
+	fn from_str(s: &str) -> Transform {
+		match s {
+			"90" => Transform::Rotation(90),
+			"180" => Transform::Rotation(180),
+			"270" => Transform::Rotation(270),
+			"flipped" => Transform::FlippedRotation(0),
+			"flipped-90" => Transform::FlippedRotation(90),
+			"flipped-180" => Transform::FlippedRotation(180),
+			"flipped-270" => Transform::FlippedRotation(270),
+			_ => Transform::Rotation(0)
+		}
+	}
+}
+
 #[derive(Debug, Default)]
 pub struct SavedOutput {
 	pub name: String,
@@ -22,7 +47,7 @@ pub struct SavedOutput {
 	pub rate: f32,
 	pub x: i32,
 	pub y: i32,
-	pub transform: String,
+	pub transform: Transform,
 	//pub reflect_x: bool,
 	//pub reflect_y: bool,
 	pub primary: bool,
@@ -91,10 +116,10 @@ impl Store for GnomeStore {
 				}
 				if let Some(c) = e.get_child("rotation") {
 					match c.text.as_ref().unwrap().trim() {
-						"right" => o.transform = "90".to_string(),
-						"inverted" => o.transform = "180".to_string(),
-						"left" => o.transform = "270".to_string(),
-						_ => o.transform = "normal".to_string(),
+						"right" => o.transform = Transform::Rotation(90),
+						"inverted" => o.transform = Transform::Rotation(180),
+						"left" => o.transform = Transform::Rotation(270),
+						_ => o.transform = Transform::Rotation(0),
 					};
 				}
 				if let Some(c) = e.get_child("primary") {
@@ -133,7 +158,7 @@ enum OutputArg {
 	Disable,
 	Resolution(i32, i32),
 	Position(i32, i32),
-	Transform(String),
+	Transform(Transform),
 	Scale(f32),
 }
 
@@ -215,7 +240,7 @@ named!(parse_transform<&[u8], OutputArg>, do_parse!(
 	tag!("transform")
 	>> parse_space
 	>> t: parse_string
-	>> (OutputArg::Transform(t))
+	>> (OutputArg::Transform(Transform::from_str(&t)))
 ));
 
 named!(parse_f32<&[u8], f32>, ws!(nom::float));


### PR DESCRIPTION
Done:
- Rotation (not yet other transforms) now supported in the normal, 90, 180, 270 variety (clockwise).
- Tested with kanshi store with addition of `rotation <0, 90, 180, 270>`.
- Untested with gnome store as I've got version 2 of monitors.xml running and can't find documentation on v1 which seems to be a different build. But should work.

To do:
- Will have to look into differences between monitors.xml v1 v2 and see how this affects implementing other transforms as the xmltree is quite different in that regard and the swaymsg command is mixed with the rotation command (i.e `transform flipped-90`)