### PR TITLE
Specify correct version in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'kanshi',
 	'c',
-	version: '0.0.0',
+	version: '1.0.0',
 	license: 'MIT',
 	meson_version: '>=0.47.0',
 	default_options: [


### PR DESCRIPTION
kanshi 1.0.0 has been released to github but meson.build was not updated
to reflect this yet.