### PR TITLE
Be tolerant to matching refresh rates that are a few points off.

### DIFF
--- a/main.c
+++ b/main.c
@@ -159,12 +159,17 @@ static const struct zwlr_output_configuration_v1_listener config_listener = {
 	.cancelled = config_handle_cancelled,
 };
 
+static bool match_refresh(const struct kanshi_mode *mode, int refresh) {
+	int v = refresh - mode->refresh;
+	return abs(v) < 50;
+}
+
 static struct kanshi_mode *match_mode(struct kanshi_head *head,
 		int width, int height, int refresh) {
 	struct kanshi_mode *mode;
 	wl_list_for_each(mode, &head->modes, link) {
 		if (mode->width == width && mode->height == height &&
-				(refresh == 0 || mode->refresh == refresh)) {
+				(refresh == 0 || match_refresh(mode, refresh))) {
 			return mode;
 		}
 	}


### PR DESCRIPTION
When specifying a referesh rate like @60Hz kanshi expects an absolute match.

Many monitors have refresh timings that are slightly off these absolute values.

e.g.  

"current_mode": {
    "width": 2560,
    "height": 1440,
    "refresh": 60012
  }

I propose to tolerate a deviation of +/- 50 1/1000th Hz.



