### PR TITLE
Fix parser_next_token return value

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -144,7 +144,7 @@ static bool parser_next_token(struct kanshi_parser *parser) {
 	while (1) {
 		int ch = parser_read_char(parser);
 		if (ch < 0) {
-			return ch;
+			return false;
 		}
 
 		if (ch == '{') {


### PR DESCRIPTION
Returning a negative value in a function with bool as return value
is the same as returning true. Fix this by returning false to indicate
failure.