### PR TITLE
add support for `output <name> mode --custom <mode>` wlr output set_custom_mode

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -21,6 +21,7 @@ struct kanshi_profile_output {
 	struct {
 		int width, height;
 		int refresh; // mHz
+		bool custom;
 	} mode;
 	struct {
 		int x, y;

--- a/main.c
+++ b/main.c
@@ -227,20 +227,31 @@ static void apply_profile(struct kanshi_state *state,
 		struct zwlr_output_configuration_head_v1 *config_head =
 			zwlr_output_configuration_v1_enable_head(config, head->wlr_head);
 		if (profile_output->fields & KANSHI_OUTPUT_MODE) {
-			// TODO: support custom modes
-			struct kanshi_mode *mode = match_mode(head,
-				profile_output->mode.width, profile_output->mode.height,
-				profile_output->mode.refresh);
-			if (mode == NULL) {
-				fprintf(stderr,
-					"output '%s' doesn't support mode '%dx%d@%fHz'\n",
-					head->name,
+			if (profile_output->mode.custom) {
+				// prints to be removed
+				printf("setting custom mode %s\n", profile_output->name);
+				printf("width %d\n", profile_output->mode.width);
+				printf("height %d\n", profile_output->mode.height);
+				printf("refresh %d\n", profile_output->mode.refresh);
+				zwlr_output_configuration_head_v1_set_custom_mode(config_head,
 					profile_output->mode.width, profile_output->mode.height,
-					(float)profile_output->mode.refresh / 1000);
-				goto error;
+					profile_output->mode.refresh);
+			} else {
+				printf("setting mode %s\n", profile_output->name);
+				struct kanshi_mode *mode = match_mode(head,
+					profile_output->mode.width, profile_output->mode.height,
+					profile_output->mode.refresh);
+				if (mode == NULL) {
+					fprintf(stderr,
+						"output '%s' doesn't support mode '%dx%d@%fHz'\n",
+						head->name,
+						profile_output->mode.width, profile_output->mode.height,
+						(float)profile_output->mode.refresh / 1000);
+					goto error;
+				}
+				zwlr_output_configuration_head_v1_set_mode(config_head,
+					mode->wlr_mode);
 			}
-			zwlr_output_configuration_head_v1_set_mode(config_head,
-				mode->wlr_mode);
 		}
 		if (profile_output->fields & KANSHI_OUTPUT_POSITION) {
 			zwlr_output_configuration_head_v1_set_position(config_head,

--- a/parser.c
+++ b/parser.c
@@ -310,6 +310,10 @@ static struct kanshi_profile_output *parse_profile_output(
 				char *value = parser->tok_str;
 				switch (key) {
 				case KANSHI_OUTPUT_MODE:
+					if (strcmp(value, "--custom") == 0) {
+						output->mode.custom = true;
+						continue;
+					}
 					if (!parse_mode(output, value)) {
 						return NULL;
 					}


### PR DESCRIPTION
(work in progress, doesn't seem to work yet for me)

using this config:
```
profile undocked {
        output LVDS-1 enable
}

profile docked {
        output LVDS-1 position 0,768
        output HDMI-A-2 mode --custom 1360x768 position 0,0
}
```

I get the prints 
```
applying profile 'docked'                                                                                                                                                                    
applying profile output 'LVDS-1' on connected head 'LVDS-1'                                                                                                                                  
applying profile output 'HDMI-A-2' on connected head 'HDMI-A-2'                                                                                                                              
setting custom HDMI-A-2                                                                                                                                                                      
width 1360                                                                                                                                                                                   
height 768                                                                                                                                                                                   
refresh 0 
```

but sway thinks otherwise

```sh
$ swaymsg -t get_outputs | jq '.[] | "\(.name) \(.current_mode)"'
"LVDS-1 {\"width\":1366,\"height\":768,\"refresh\":60103}"
"HDMI-A-2 {\"width\":1280,\"height\":800,\"refresh\":59910}"
```