### PR TITLE
Add 'include' directive to read additional configs

### DIFF
--- a/kanshi.5.scd
+++ b/kanshi.5.scd
@@ -6,12 +6,14 @@ kanshi - configuration file
 
 # DESCRIPTION
 
-A kanshi configuration file is a list of profiles. Each profile has an
-optional name and contains directives delimited by brackets (*{* and *}*).
+A kanshi configuration file is a list of profiles. Each profile has an optional
+name and contains profile directives delimited by brackets (*{* and *}*).
 
 Example:
 
 ```
+include /etc/kanshi/config.d/*
+
 profile {
 	output LVDS-1 disable
 	output "Some Company ASDF 4242" mode 1600x900 position 0,0
@@ -24,8 +26,18 @@ profile nomad {
 
 # DIRECTIVES
 
-Directives are followed by space-separated arguments. Arguments can be quoted
-(with *"*) if they contain spaces.
+*profile* [<name>] { <profile directives...> }
+	Defines a new profile using the specified bracket-delimited profile
+	directives. A name can be specified but is optional.
+
+*include* <path>
+	Include as another file from _path_. Expands shell syntax (see *wordexp*(3)
+	for details).
+
+# PROFILE DIRECTIVES
+
+Profile directives are followed by space-separated arguments. Arguments can be
+quoted (with *"*) if they contain spaces.
 
 *output* <criteria> <output-command...>
 	An output directive adds an output to the profile. The criteria can either


### PR DESCRIPTION
Similar to #68. Notable differences:

1. Uses the literal `include`, rather than `!include`, as the profile keyword has been added.
2. Uses **wordexp**(3) to perform full shell-like expansion with all the bells and whistles, rather than implementing this manually and partially.

Questions:
1. Do we want to make includes relative to the current config file like e.g. sway does? This will require some chdir dance.
2. Do we want to fail if included files could not be parsed, or just silently continue? This patch currently does the former.