### PR TITLE
Switch to scfg

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -5,23 +5,6 @@
 
 struct kanshi_config;
 
-enum kanshi_token_type {
-	KANSHI_TOKEN_LBRACKET,
-	KANSHI_TOKEN_RBRACKET,
-	KANSHI_TOKEN_STR,
-	KANSHI_TOKEN_NEWLINE,
-};
-
-struct kanshi_parser {
-	FILE *f;
-	int next;
-	int line, col;
-
-	enum kanshi_token_type tok_type;
-	char tok_str[1024];
-	size_t tok_str_len;
-};
-
 struct kanshi_config *parse_config(const char *path);
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ add_project_arguments(cc.get_supported_arguments([
 ]), language: 'c')
 
 wayland_client = dependency('wayland-client')
+scfg = dependency('scfg')
 
 subdir('protocol')
 
@@ -45,7 +46,7 @@ executable(
 		'parser.c',
 	),
 	include_directories: include_directories('include'),
-	dependencies: [wayland_client, client_protos],
+	dependencies: [wayland_client, client_protos, scfg],
 	install: true,
 )
 


### PR DESCRIPTION
Switch to [libscfg](https://git.sr.ht/~emersion/libscfg) instead of using our own parser.

- [ ] Figure out if/how to handle legacy profiles without a directive name
- [ ] Add back line/col info