### PR TITLE
parser: explicitly initialize key (kanshi_output_field) to 0

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -299,7 +299,7 @@ static struct kanshi_profile_output *parse_profile_output(
 	output->name = strdup(parser->tok_str);
 
 	bool has_key = false;
-	enum kanshi_output_field key;
+	enum kanshi_output_field key = 0;
 	while (1) {
 		if (!parser_next_token(parser)) {
 			return NULL;


### PR DESCRIPTION
This warning is tripped by GCC 10.