### PR TITLE
Parser: add mode synonyms "resolution" and "res"

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -348,7 +348,9 @@ static struct kanshi_profile_output *parse_profile_output(
 					output->enabled = false;
 					output->fields |= KANSHI_OUTPUT_ENABLED;
 					has_key = false;
-				} else if (strcmp(key_str, "mode") == 0) {
+				} else if (strcmp(key_str, "mode") == 0 ||
+					   strcmp(key_str, "resolution") == 0 ||
+					   strcmp(key_str, "res") == 0) {
 					key = KANSHI_OUTPUT_MODE;
 				} else if (strcmp(key_str, "position") == 0) {
 					key = KANSHI_OUTPUT_POSITION;


### PR DESCRIPTION
These synonyms are documented in sway-output (5).

I was using `resolution` in my sway config, so I discovered that and decided to fix it.

Untested, but the change should be fairly trivial. I'm not entirely sure about code alignment, it depends on your tab width.