### PR TITLE
Add IPC method to select a profile

### DIFF
--- a/include/kanshi.h
+++ b/include/kanshi.h
@@ -54,6 +54,7 @@ struct kanshi_state {
 	uint32_t serial;
 	struct kanshi_profile *current_profile;
 	struct kanshi_profile *pending_profile;
+	char *selected_profile_name;
 };
 
 struct kanshi_pending_profile {

--- a/include/kanshi.h
+++ b/include/kanshi.h
@@ -63,6 +63,7 @@ struct kanshi_pending_profile {
 };
 
 bool kanshi_reload_config(struct kanshi_state *state);
+bool kanshi_set_profile(struct kanshi_state *state, const char *name);
 
 int kanshi_main_loop(struct kanshi_state *state);
 

--- a/kanshictl.1.scd
+++ b/kanshictl.1.scd
@@ -17,6 +17,8 @@ kanshictl - control the kanshi daemon remotely
 
 reload - reload the config file
 
+set-profile <profile name> - try to apply a named profile
+
 # AUTHORS
 
 Maintained by Simon Ser <contact@emersion.fr>, who is assisted by other

--- a/main.c
+++ b/main.c
@@ -38,6 +38,11 @@ static bool match_profile(struct kanshi_state *state,
 
 	memset(matches, 0, HEADS_MAX * sizeof *matches);
 
+	if (state->selected_profile_name != NULL && profile->name != NULL &&
+			  strcmp(state->selected_profile_name, profile->name) != 0) {
+		 return false;
+	}
+
 	// Wildcards are stored at the end of the list, so those will be matched
 	// last
 	struct kanshi_profile_output *profile_output;
@@ -527,6 +532,8 @@ bool kanshi_reload_config(struct kanshi_state *state) {
 		state->config = config;
 		state->pending_profile = NULL;
 		state->current_profile = NULL;
+		free(state->selected_profile_name);
+		state->selected_profile_name = NULL;
 		return try_apply_profiles(state);
 	}
 	return false;

--- a/main.c
+++ b/main.c
@@ -36,7 +36,7 @@ static bool match_profile(struct kanshi_state *state,
 		return false;
 	}
 
-	memset(matches, 0, HEADS_MAX * sizeof(struct kanshi_head *));
+	memset(matches, 0, HEADS_MAX * sizeof *matches);
 
 	// Wildcards are stored at the end of the list, so those will be matched
 	// last

--- a/main.c
+++ b/main.c
@@ -83,7 +83,6 @@ static struct kanshi_profile *match(struct kanshi_state *state,
 	return NULL;
 }
 
-
 static void exec_command(char *cmd) {
 	pid_t child, grandchild;
 	// Fork process
@@ -430,6 +429,10 @@ static bool try_apply_profiles(struct kanshi_state *state) {
 	assert(wl_list_length(&state->heads) <= HEADS_MAX);
 	// matches[i] gives the kanshi_profile_output for the i-th head
 	struct kanshi_profile_output *matches[HEADS_MAX];
+	if (state->current_profile && match_profile(state, state->current_profile, matches)) {
+		//apply_profile?
+		return true;
+	}
 	struct kanshi_profile *profile = match(state, matches);
 	if (profile != NULL) {
 		apply_profile(state, profile, matches);
@@ -537,6 +540,16 @@ bool kanshi_reload_config(struct kanshi_state *state) {
 		return try_apply_profiles(state);
 	}
 	return false;
+}
+
+bool kanshi_set_profile(struct kanshi_state *state, const char *name) {
+	fprintf(stderr, "loading profile %s\n", name);
+	free(state->selected_profile_name);
+	state->selected_profile_name = strdup(name);
+	if (state->selected_profile_name == NULL) {
+		return false;
+	}
+	return try_apply_profiles(state);
 }
 
 static const char usage[] = "Usage: %s [options...]\n"


### PR DESCRIPTION
This "works", in the sense that the server receives the request and applies the profile. However, it seems that it immediately triggers a "detected change" event, and the server applies the old profile again:

```
applying profile 'home_desk'
applying profile output 'LG HDR WFHD' on connected head 'DP-3'
applying profile output 'eDP-1' on connected head 'eDP-1'
running commands for configuration 'home_desk'
configuration for profile 'home_desk' applied <------ HERE is where I call kanshictl
loading profile only_external
applying profile 'only_external'
applying profile output 'LG HDR WFHD' on connected head 'DP-3'
applying profile output 'eDP-1' on connected head 'eDP-1'
running commands for configuration 'only_external'
configuration for profile 'only_external' applied
applying profile 'home_desk' <------- THIS starts immediately
applying profile output 'LG HDR WFHD' on connected head 'DP-3'
applying profile output 'eDP-1' on connected head 'eDP-1'
running commands for configuration 'home_desk'
configuration for profile 'home_desk' applied
```

I'm looking into the code to try and understand how to make this not happen, but would definitely appreciate tips on where to look :)

I hope my approach is correct, too.